### PR TITLE
Adds the expected AssetForm class

### DIFF
--- a/app/forms/curation_concerns/asset_form.rb
+++ b/app/forms/curation_concerns/asset_form.rb
@@ -1,0 +1,5 @@
+module CurationConcerns
+  class AssetForm < CurationConcerns::Forms::WorkForm
+    self.model_class = ::Asset
+  end
+end


### PR DESCRIPTION
Forms in later releases of CurationConcerns are now created with generators.
    
    # For instance this would create everything needed to create an 'Asset'
    # instance, including the AssetForm class.
    rails generate curation_concerns:work Asset