### PR TITLE
Refactor spec fixtures just a little

### DIFF
--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,18 +1,26 @@
 module Fixtures
 
-  def fixture(relative_path)
-    fixture_file = File.join(Fixtures.path, relative_path)
-    raise NotFound, "Fixture file #{fixture_file} does not exist" unless File.exists?(fixture_file)
-    File.read(fixture_file)
-  end
-
-  def self.path
+  def self.base_path
     # Default path is ../../fixtures, relative to this file.
-    @path ||= File.expand_path('fixtures', File.dirname(File.dirname(__FILE__)))
+    @base_path ||= File.expand_path('fixtures', File.dirname(File.dirname(__FILE__)))
   end
 
-  def self.path=(path)
-    @path = path
+  def self.base_path=(base_path)
+    @base_path = base_path
+  end
+
+  def self.full_path(relative_path)
+    File.join(Fixtures.base_path, relative_path)
+  end
+
+  def self.open(relative_path, opts={})
+    filename = full_path(relative_path)
+    raise NotFound, "Fixture file #{filename} does not exist" unless File.exists?(filename)
+    File.open(filename, 'r')
+  end
+
+  def self.read(relative_path)
+    open(relative_path).read
   end
 
   class NotFound < StandardError; end

--- a/spec/support/fixtures_spec.rb
+++ b/spec/support/fixtures_spec.rb
@@ -1,9 +1,5 @@
 require_relative 'fixtures'
 
-RSpec.configure do |config|
-  config.include Fixtures
-end
-
 describe Fixtures do
 
   before(:all) do
@@ -11,21 +7,31 @@ describe Fixtures do
     FileUtils.mkdir_p(@tmp_dir)
     # Write a sample fixture
     File.open(File.join(@tmp_dir, 'foo.txt'), 'w') { |f| f.write("bar") }
-    Fixtures.path = @tmp_dir
+    Fixtures.base_path = @tmp_dir
   end
 
   after(:all) do
     FileUtils.remove_entry_secure(@tmp_dir)
-    Fixures.path = nil
+    Fixtures.base_path = nil
   end
 
-  describe '#fixture' do
-    it 'loads a fixture' do
-      expect(fixture('foo.txt')).to eq 'bar'
+  describe '.read' do
+    it 'returns the contents of a fixture file' do
+      expect(Fixtures.read('foo.txt')).to eq 'bar'
+    end
+  end
+
+  describe '.open' do
+
+    subject { Fixtures.open('foo.txt') }
+
+    it 'returns a File object for the fixture file' do
+      expect(subject).to be_a File
+      expect(File.basename(subject.path)).to eq 'foo.txt'
     end
 
-    it 'raises an error if the fixture does not exist' do
-      expect { fixture('bogux') }.to raise_error Fixtures::NotFound
+    it 'raises an error if the fixture file does not exist' do
+      expect { Fixtures.open('bogus') }.to raise_error Fixtures::NotFound
     end
   end
 


### PR DESCRIPTION
We basically just want a minimal wrapper around File.read, File.open that
allows you to sepcify files relative to a base path, and gives specific errors
when it breaks.