### PR TITLE
Sets filename property from attached FITS file.

### DIFF
--- a/lib/hydradam/file_set_behavior/has_fits.rb
+++ b/lib/hydradam/file_set_behavior/has_fits.rb
@@ -16,6 +16,14 @@ module HydraDAM
 
         # TODO: replace bogus predicate with legit one.
         directly_contains_one :fits, through: :files, type: ::RDF::URI('http://example.org/TODO-replace-with-actual-predicate'), class_name: 'XMLFile'
+
+        apply_schema Hydra::Works::Characterization::BaseSchema, Hydra::Works::Characterization::AlreadyThereStrategy
+      end
+
+      def assign_properties_from_fits
+        noko = fits.noko.dup
+        noko.remove_namespaces!
+        self.filename = noko.xpath('//fits/fileinfo/filename').text
       end
     end
   end

--- a/spec/lib/hydradam/file_set_behavior/has_fits_spec.rb
+++ b/spec/lib/hydradam/file_set_behavior/has_fits_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 require 'hydradam/file_set_behavior/has_fits'
-require 'pry'
 
 describe HydraDAM::FileSetBehavior::HasFITS, :requires_fedora do
 
@@ -29,6 +28,21 @@ describe HydraDAM::FileSetBehavior::HasFITS, :requires_fedora do
     it 'accepts a XMLFile' do
       subject.save! # the parent object must be saved before attaching files.
       expect{ subject.fits = XMLFile.new }.to_not raise_error
+    end
+  end
+
+
+  describe '#assign_properties_from_fits' do
+
+    let(:fits_file) { File.open('./spec/fixtures/fits/fits_0_8_10.xml') }
+
+    before do
+      Hydra::Works::AddFileToFileSet.call(subject, fits_file, :fits)
+      subject.assign_properties_from_fits
+    end
+
+    it 'assigns values from FITS XML file to RDF properties on the object' do
+      expect(subject.filename).to eq "SANY0473.MP4"
     end
   end
 


### PR DESCRIPTION
* Applies the Hydra Works basic characterization schema for models that include
  HydraDAM::FileSetBehavior::HasFITS. This schema includes a :filename property
  among others that align with FITS metadata.
* Adds a #assign_property_from_fits method to the HasFITS module, which assigns
  the :filename property from the attached FITS file.

Closes #58. Toward HDM-260.