### PR TITLE
64 attach exif xml files

### DIFF
--- a/lib/hydradam/file_set_behavior/has_exif.rb
+++ b/lib/hydradam/file_set_behavior/has_exif.rb
@@ -1,0 +1,22 @@
++require 'depends_on'
+ +
+ +module HydraDAM
+ +  module FileSetBehavior
+ +    module HasEXIF
+ +      extend ActiveSupport::Concern
+ +
+ +      included do
+ +
+ +        # Ensure class dependencies
+ +        include DependsOn
+ +        depends_on(ActiveFedora::Base)
+ +
+ +        # Ensure module dependencies
+ +        include Hydra::Works::FileSetBehavior
+ +
+ +        # TODO: replace bogus predicate with legit one.
+ +        directly_contains_one :exif, through: :files, type: ::RDF::URI('http://example.org/TODO-replace-with-actual-predicate'), class_name: 'XMLFile'
+ +      end
+ +    end
+ +  end
+ +end 

--- a/lib/hydradam/file_set_behavior/has_exif.rb
+++ b/lib/hydradam/file_set_behavior/has_exif.rb
@@ -1,22 +1,30 @@
-+require 'depends_on'
- +
- +module HydraDAM
- +  module FileSetBehavior
- +    module HasEXIF
- +      extend ActiveSupport::Concern
- +
- +      included do
- +
- +        # Ensure class dependencies
- +        include DependsOn
- +        depends_on(ActiveFedora::Base)
- +
- +        # Ensure module dependencies
- +        include Hydra::Works::FileSetBehavior
- +
- +        # TODO: replace bogus predicate with legit one.
- +        directly_contains_one :exif, through: :files, type: ::RDF::URI('http://example.org/TODO-replace-with-actual-predicate'), class_name: 'XMLFile'
- +      end
- +    end
- +  end
- +end 
+require 'depends_on'
+
+module HydraDAM
+  module FileSetBehavior
+    module HasEXIF
+      extend ActiveSupport::Concern
+
+      included do
+
+        # Ensure class dependencies
+        include DependsOn
+        depends_on(ActiveFedora::Base)
+
+        # Ensure module dependencies
+        include Hydra::Works::FileSetBehavior
+
+        # TODO: replace bogus predicate with legit one.
+        directly_contains_one :exif, through: :files, type: ::RDF::URI('http://example.org/TODO-replace-with-actual-predicate'), class_name: 'XMLFile'
+
+        apply_schema Hydra::Works::Characterization::BaseSchema, Hydra::Works::Characterization::AlreadyThereStrategy
+      end
+
+      def assign_properties_from_exif
+        noko = exif.noko.dup
+        noko.remove_namespaces!
+        self.filename = noko.xpath('//FileName').text
+      end
+    end
+  end
+end 

--- a/spec/lib/hydradam/file_set_behavior/has_exif_spec.rb
+++ b/spec/lib/hydradam/file_set_behavior/has_exif_spec.rb
@@ -42,7 +42,7 @@ describe HydraDAM::FileSetBehavior::HasEXIF, :requires_fedora do
     end
 
     it 'assigns values from EXIF XML file to RDF properties on the object' do
-      expect(subject.filename).to eq "SANY0473.MP4"
+      expect(subject.filename).to eq "2 Schuman_a.aiff"
     end
   end
 

--- a/spec/lib/hydradam/file_set_behavior/has_exif_spec.rb
+++ b/spec/lib/hydradam/file_set_behavior/has_exif_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require 'hydradam/file_set_behavior/has_exif'
+
+describe HydraDAM::FileSetBehavior::HasEXIF, :requires_fedora do
+
+  subject do
+    # An anonymous class that inherits from ActiveFedora::Base
+    # and includes the HydraDAM::FileSetBehavior::HasFITS module.
+    Class.new(ActiveFedora::Base) do
+      include HydraDAM::FileSetBehavior::HasEXIF
+    end.new
+  end
+
+  after(:all) do
+    subject.delete rescue nil
+  end
+
+  it 'exposes accessors #exif and #exif=' do
+    expect(subject).to respond_to :exif
+    expect(subject).to respond_to :"exif="
+  end
+
+  describe '#exif=' do
+    it 'requires an XMLFile' do
+      expect{ subject.exif = "this will fail" }.to raise_error
+    end
+
+    it 'accepts a XMLFile' do
+      subject.save! # the parent object must be saved before attaching files.
+      expect{ subject.exif = XMLFile.new }.to_not raise_error
+    end
+  end
+
+
+  describe '#assign_properties_from_exif' do
+
+    let(:exif_file) { File.open('./spec/fixtures/exiftool/exiftool_9_94.xml') }
+
+    before do
+      Hydra::Works::AddFileToFileSet.call(subject, exif_file, :exif)
+      subject.assign_properties_from_exif
+    end
+
+    it 'assigns values from EXIF XML file to RDF properties on the object' do
+      expect(subject.filename).to eq "SANY0473.MP4"
+    end
+  end
+
+  context 'when the including class does not inherit from ActiveFedora::Base' do
+
+    let(:class_with_missing_dependency) do
+      # An anonymous class that includes the HydraDAM::FileSetBehavior::HasEXIF
+      # module but does not inherity from ActiveFedora::Base like it should
+      Class.new do
+        include HydraDAM::FileSetBehavior::HasEXIF
+      end
+    end
+
+    it 'raises an error' do
+      expect{ class_with_missing_dependency }.to raise_error DependsOn::MissingDependencies
+    end
+  end
+end


### PR DESCRIPTION
file set objects have an accessor named :exif that accepts an instance of Hydra::PCDM::File, or subclass thereof.