### PR TITLE
Create a rake task to ingest a single tarball file.

### DIFF
--- a/lib/tasks/hydradam-iu.rake
+++ b/lib/tasks/hydradam-iu.rake
@@ -1,0 +1,13 @@
+require 'IU/ingest/sip'
+
+namespace :hydradam do
+  namespace :iu do
+    desc 'Ingest a SIP tarball'
+    task :ingest, [:username, :file] => :environment do |task, args|
+      user = User.find_by_email args.username
+      sip = IU::Ingest::SIP.new(depositor: user, tarball: args.file)
+      sip.ingest!
+      print "Ingest complete. Object id: #{sip.work.id}\n"
+    end
+  end
+end


### PR DESCRIPTION
This puts the commands used to ingest a file into a rake task with arguments. Example usage:

```bash
rake hydradam:iu:ingest[user@example.com,path/to/tarball/file]
```