### PR TITLE
HDM-394 Display attributes of HydraDAM FileSets.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -18,10 +18,12 @@ class CatalogController < ApplicationController
              solr_name('description', :stored_searchable),
              solr_name('filename', :stored_searchable),
              solr_name('file_format', :stored_searchable),
+             solr_name('quality_level', :stored_searchable),
              solr_name('lto_path', :stored_searchable),
              solr_name('artesia_uoi_id', :stored_searchable),
              solr_name('creator', :stored_searchable),
-             solr_name('original_checksum', :stored_searchable)
+             solr_name('original_checksum', :symbol),
+             'file_size_ltsi', 'file_size_mb_ltsi'
       ],
       qt: 'search',
       rows: 10
@@ -48,8 +50,9 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('language', :facetable), limit: 5
     config.add_facet_field solr_name('based_near', :facetable), limit: 5
     config.add_facet_field solr_name('publisher', :facetable), limit: 5
-    config.add_facet_field solr_name('file_format', :symbol), limit: 5
-    config.add_facet_field solr_name('depositor', :symbol), limit: 5
+    config.add_facet_field solr_name('file_format', :symbol), label: 'File Format', limit: 5
+    config.add_facet_field solr_name('depositor', :symbol),label: 'Depositor', limit: 5
+    config.add_facet_field solr_name('quality_level', :stored_searchable), label: 'Quality Level', limit: 5
     config.add_facet_field 'file_size_mb_ltsi', label: 'File Size (MB)', limit: 5, range: true
 
 
@@ -100,7 +103,7 @@ class CatalogController < ApplicationController
       label_name = solr_name('title', :stored_searchable, type: :string)
       contributor_name = solr_name('contributor', :stored_searchable, type: :string)
       field.solr_parameters = {
-        qf: "#{title_name} #{label_name} file_format_tesim #{contributor_name} file_size_ltsi",
+        #qf: "#{title_name} #{label_name} file_format_tesim #{contributor_name} file_size_ltsi",
         pf: title_name.to_s
       }
     end

--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -19,6 +19,11 @@ class FileSetIndexer < CurationConcerns::FileSetIndexer
       facetable_file_format = Solrizer.solr_name('file_format', :facetable)
       solr_doc[facetable_file_format] ||= []
       solr_doc[facetable_file_format] += object.file_format
+
+      solr_doc[Solrizer.solr_name(:quality_level, :stored_searchable)] = object.quality_level
+      solr_doc[Solrizer.solr_name(:original_checksum, :symbol)] = object.original_checksum
+
+
     end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -23,4 +23,22 @@ class SolrDocument
   # Do content negotiation for AF models. 
 
   use_extension( Hydra::ContentNegotiation )
+
+  def filename
+    File.basename(fetch(Solrizer.solr_name(:filename, :stored_searchable), []).first)
+  end
+
+  def file_size
+    fetch(Solrizer.solr_name(:file_size, Solrizer::Descriptor.new(:long, :stored, :indexed)), [])
+  end
+
+  def quality_level
+    fetch(Solrizer.solr_name(:quality_level, :stored_searchable), [])
+  end
+
+  def original_checksum
+    fetch(Solrizer.solr_name(:original_checksum, :symbol), [])
+  end
+
+
 end

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -1,0 +1,38 @@
+module CurationConcerns
+  class FileSetPresenter
+    include ModelProxy
+    include PresentsAttributes
+    attr_accessor :solr_document, :current_ability
+
+    # @param [SolrDocument] solr_document
+    # @param [Ability] current_ability
+    def initialize(solr_document, current_ability)
+      @solr_document = solr_document
+      @current_ability = current_ability
+    end
+
+    # CurationConcern methods
+    delegate :stringify_keys, :human_readable_type, :collection?, :image?, :video?,
+             :audio?, :pdf?, :office_document?, :representative_id, :to_s, to: :solr_document
+
+    # Methods used by blacklight helpers
+    delegate :has?, :first, :fetch, to: :solr_document
+
+    # Metadata Methods
+    delegate :title, :description, :creator, :contributor, :subject, :publisher,
+             :language, :date_uploaded, :rights,
+             :embargo_release_date, :lease_expiration_date,
+             :depositor, :tags, :title_or_label, to: :solr_document
+
+    delegate :filename, :file_format, :file_size, :original_checksum, :quality_level, to: :solr_document
+
+
+    def page_title
+      Array(solr_document['label_tesim']).first
+    end
+
+    def link_name
+      current_ability.can?(:read, id) ? Array(solr_document['label_tesim']).first : 'File'
+    end
+  end
+end

--- a/app/views/curation_concerns/file_sets/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/file_sets/_attribute_rows.html.erb
@@ -1,0 +1,12 @@
+  <%= presenter.attribute_to_html(:description) %>
+  <%= presenter.attribute_to_html(:creator, catalog_search_link: true ) %>
+  <%= presenter.attribute_to_html(:contributor, label: 'Contributors', catalog_search_link: true) %>
+  <%= presenter.attribute_to_html(:subject, catalog_search_link: true) %>
+  <%= presenter.attribute_to_html(:publisher) %>
+  <%= presenter.attribute_to_html(:language) %>
+
+  <%= presenter.attribute_to_html(:filename, catalog_search_link: true) %>
+  <%= presenter.attribute_to_html(:quality_level, catalog_search_link: true) %>
+  <%= presenter.attribute_to_html(:file_format, catalog_search_link: true) %>
+  <%= presenter.attribute_to_html(:file_size, label: 'File Size (bytes)') %>
+  <%= presenter.attribute_to_html(:original_checksum, label: 'Checksum', catalog_search_link: true) %>

--- a/spec/lib/IU/ingest/sip_spec.rb
+++ b/spec/lib/IU/ingest/sip_spec.rb
@@ -39,6 +39,10 @@ describe IU::Ingest::SIP do
     it 'gets its value for #original_checksum from the SIP checksum manifest' do
       expect(sip.access_copy.original_checksum).to eq ['2e779723fdf58b5b2a60d2f71e7f2fe7']
     end
+
+    it 'stores its quality level' do
+      expect(sip.access_copy.quality_level.to_s).to eq 'access'
+    end
   end
 
   describe '#mezzanine_copy' do
@@ -53,6 +57,10 @@ describe IU::Ingest::SIP do
 
     it 'gets its value for #original_checksum from the SIP checksum manifest' do
       expect(sip.mezzanine_copy.original_checksum).to eq ['e5059f5b149f1688d39d0cf4c3d2a143']
+    end
+
+    it 'stores its quality level' do
+      expect(sip.mezzanine_copy.quality_level.to_s).to eq 'mezzanine'
     end
   end
 


### PR DESCRIPTION
Displays attributes from FileSets in their show/detail view.
Also adds indexing of several fields: original_checksum, quality_level, filename.
Some CatalogController cleanup also happened.