### PR TITLE
HDM-429 Use ordered_members when attaching FileSets.

### DIFF
--- a/app/models/concerns/work_behavior.rb
+++ b/app/models/concerns/work_behavior.rb
@@ -19,7 +19,7 @@ module Concerns
     end
 
     def members_of_quality_level(quality_level)
-      members.select { |member| member.try(:quality_level) == quality_level }
+      ordered_members.to_a.select { |member| member.try(:quality_level) == quality_level }
     end
 
     def assign_properties_from_mdpi_xml

--- a/lib/IU/ingest/sip.rb
+++ b/lib/IU/ingest/sip.rb
@@ -15,8 +15,8 @@ module IU
       # Establish relationships between all the objects created from SIP files
       # extracted form the tarball.
       def ingest!
-        work.members << access_copy
-        work.members << mezzanine_copy
+        work.ordered_members << access_copy
+        work.ordered_members << mezzanine_copy
         work.save!
         delete_extracted_files!
       end


### PR DESCRIPTION
This is the simplest fix to make our ingests display their related objects in the UI.

Later we may want to refactor to use actors in curation_concerns 1.0.