### PR TITLE
Handles LoadErrors in rake tasks.

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,8 +1,12 @@
-require 'solr_wrapper'
-require 'fcrepo_wrapper'
-require 'active_fedora/rake_support'
-task ci: ['engine_cart:generate'] do
-  with_server('test') do
-    Rake::Task['spec'].invoke
+begin
+  require 'solr_wrapper'
+  require 'fcrepo_wrapper'
+  require 'active_fedora/rake_support'
+  task ci: ['engine_cart:generate'] do
+    with_server('test') do
+      Rake::Task['spec'].invoke
+    end
   end
+rescue LoadError => e
+  puts e.message
 end

--- a/lib/tasks/hydradam_tasks.rake
+++ b/lib/tasks/hydradam_tasks.rake
@@ -1,17 +1,21 @@
-require 'solr_wrapper'
-require 'fcrepo_wrapper'
-require 'active_fedora/rake_support'
+begin
+  require 'solr_wrapper'
+  require 'fcrepo_wrapper'
+  require 'active_fedora/rake_support'
 
-namespace :hydradam do
-  desc "Start development servers"
-  task :dev_servers do
-    with_server('development') do
-      begin
-        sleep
-      rescue Interrupt
-        puts "Stopping development servers"
+  namespace :hydradam do
+    desc "Start development servers"
+    task :dev_servers do
+      with_server('development') do
+        begin
+          sleep
+        rescue Interrupt
+          puts "Stopping development servers"
+        end
+
       end
-
     end
   end
+rescue LoadError => e
+  puts e.message
 end


### PR DESCRIPTION
Fixes HDM-583. The bug was due to a missing database table. The table was not
being created for the test app because the rake task responsible for generating
the migration was failing. The failure was due to the LoadErrors, which this
commit fixes.
